### PR TITLE
Set yield active toggles to off

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -63,8 +63,8 @@ export default function PyUSDYieldSelector() {
 
   // Yield toggle states
   const [conservativeYieldEnabled, setConservativeYieldEnabled] =
-    useState(true);
-  const [growthYieldEnabled, setGrowthYieldEnabled] = useState(true);
+    useState(false);
+  const [growthYieldEnabled, setGrowthYieldEnabled] = useState(false);
 
   // Load Venmo address from localStorage on component mount
   useEffect(() => {


### PR DESCRIPTION
The default state of yield active toggles was updated in `app/dashboard/page.tsx`.

Specifically:
*   The initial state for `conservativeYieldEnabled` was changed from `useState(true)` to `useState(false)`.
*   The initial state for `growthYieldEnabled` was changed from `useState(true)` to `useState(false)`.

This modification ensures that both Conservative Vault and Growth Vault yield toggles are in the OFF position by default when the dashboard loads. The change provides a safer default behavior, requiring users to explicitly opt-in to yield earning rather than having it enabled automatically.