### PR TITLE
Add link to sepolia etherscan

### DIFF
--- a/app/cookbook/page.tsx
+++ b/app/cookbook/page.tsx
@@ -4467,9 +4467,27 @@ export default function CookbookPage() {
             >
               🔄 Swap PYUSD → USDC
             </button>
-            <p className='mt-2 text-sm text-purple-700'>
-              Status: {poolData.swapStatus}
-            </p>
+            <div className='mt-2'>
+              <p className='text-sm text-purple-700'>
+                Status: {poolData.swapStatus.includes('Tx: ') ?
+                  poolData.swapStatus.split('Tx: ')[0] : poolData.swapStatus}
+              </p>
+              {poolData.swapStatus.includes('Tx: ') && (
+                <div className='mt-1'>
+                  <p className='text-xs text-gray-500'>
+                    Transaction Hash:
+                    <a
+                      href={`https://sepolia.etherscan.io/tx/${poolData.swapStatus.split('Tx: ')[1]}`}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='ml-1 font-mono text-blue-600 underline hover:text-blue-800'
+                    >
+                      {poolData.swapStatus.split('Tx: ')[1]}
+                    </a>
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Liquidity Section */}
@@ -4509,9 +4527,27 @@ export default function CookbookPage() {
             >
               🏊 Add Liquidity
             </button>
-            <p className='mt-2 text-sm text-red-700'>
-              Status: {poolData.liquidityStatus}
-            </p>
+            <div className='mt-2'>
+              <p className='text-sm text-red-700'>
+                Status: {poolData.liquidityStatus.includes('Tx: ') ?
+                  poolData.liquidityStatus.split('Tx: ')[0] : poolData.liquidityStatus}
+              </p>
+              {poolData.liquidityStatus.includes('Tx: ') && (
+                <div className='mt-1'>
+                  <p className='text-xs text-gray-500'>
+                    Transaction Hash:
+                    <a
+                      href={`https://sepolia.etherscan.io/tx/${poolData.liquidityStatus.split('Tx: ')[1]}`}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='ml-1 font-mono text-blue-600 underline hover:text-blue-800'
+                    >
+                      {poolData.liquidityStatus.split('Tx: ')[1]}
+                    </a>
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Error Display */}


### PR DESCRIPTION
In `app/cookbook/page.tsx`, the display of transaction hashes for "Swap Status" and "Liquidity Status" was updated. Previously, these hashes were presented as plain text.

*   The `poolData.swapStatus` and `poolData.liquidityStatus` sections now conditionally render a clickable Etherscan link.
*   If the status string contains "Tx: ", the transaction hash is extracted from the string.
*   This hash is then used to construct an `<a>` tag with its `href` attribute pointing to `https://sepolia.etherscan.io/tx/{hash}`.
*   The links are configured to open in a new browser tab using `target='_blank'` and include `rel='noopener noreferrer'` for security.

This modification ensures all transaction hashes within the cookbook page are consistently linked to Sepolia Etherscan, improving navigability and user experience.