### PR TITLE
Integrate KYC badge logic on profile page

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePrivy } from '@privy-io/react-auth';
-import { ArrowRight, Edit3, Globe, User, Zap } from 'lucide-react';
+import { ArrowRight, Edit3, Globe, Lock, User, Zap } from 'lucide-react';
 import Image from 'next/image';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -57,6 +57,20 @@ const formatPyusdBalance = (balance: bigint): string => {
   });
 };
 
+// KYC Contract configuration
+const KYC_CONTRACT_CONFIG = {
+  address: '0xcc8e8b424464991bbcda036c4781a60334c40628' as const,
+  abi: [
+    {
+      name: 'balanceOf',
+      type: 'function',
+      inputs: [{ name: 'owner', type: 'address' }],
+      outputs: [{ name: '', type: 'uint256' }],
+      stateMutability: 'view',
+    },
+  ] as const,
+};
+
 export default function PyUSDYieldSelector() {
   const [conservativeAmount, setConservativeAmount] = useState('');
   const [growthAmount, setGrowthAmount] = useState('');
@@ -76,10 +90,43 @@ export default function PyUSDYieldSelector() {
   // Privy hooks
   const { user, authenticated, ready } = usePrivy();
 
+  // KYC state management
+  const [hasKycToken, setHasKycToken] = useState(false);
+
   // Get smart wallet from user's linked accounts
   const smartWallet = user?.linkedAccounts?.find(
     (account: any) => account.type === 'smart_wallet'
   ) as { address: string } | undefined;
+
+  // Function to check KYC token balance
+  const checkKycTokenBalance = useCallback(async () => {
+    if (!user?.wallet?.address) return;
+
+    try {
+      // Import viem utilities dynamically
+      const { createPublicClient, http } = await import('viem');
+      const { bscTestnet } = await import('viem/chains');
+
+      const publicClient = createPublicClient({
+        chain: bscTestnet,
+        transport: http('https://data-seed-prebsc-1-s1.binance.org:8545'),
+      });
+
+      // Check KYC token balance
+      const balance = await publicClient.readContract({
+        address: KYC_CONTRACT_CONFIG.address,
+        abi: KYC_CONTRACT_CONFIG.abi,
+        functionName: 'balanceOf',
+        args: [user.wallet.address as `0x${string}`],
+      });
+
+      const hasTokens = Number(balance) > 0;
+      setHasKycToken(hasTokens);
+    } catch (error) {
+      console.error('Error checking KYC balance:', error);
+      setHasKycToken(false);
+    }
+  }, [user]);
 
   // Function to fetch PYUSD balance for MetaMask wallet
   const fetchMetaMaskBalance = useCallback(async () => {
@@ -293,6 +340,9 @@ export default function PyUSDYieldSelector() {
         fetchMetaMaskBalance();
         setShowSmartWallet(true);
       }
+
+      // Check KYC token balance
+      checkKycTokenBalance();
     }, 100); // Small delay to prevent flickering
 
     return () => clearTimeout(checkOnboarding);
@@ -303,6 +353,7 @@ export default function PyUSDYieldSelector() {
     smartWallet,
     onboardingChecked,
     fetchMetaMaskBalance,
+    checkKycTokenBalance,
   ]);
 
   // Calculate total balance
@@ -415,9 +466,14 @@ export default function PyUSDYieldSelector() {
               {/* Profile Icon - Direct Link */}
               <a
                 href='/profile'
-                className='flex items-center space-x-2 rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200'
+                className='relative flex items-center space-x-2 rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200'
               >
                 <User className='h-5 w-5 text-gray-600' />
+                {hasKycToken && (
+                  <div className='absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-green-500'>
+                    <Lock className='h-2.5 w-2.5 text-white' />
+                  </div>
+                )}
               </a>
 
               {/* Network Status Dropdown */}


### PR DESCRIPTION
A new API route, `/app/api/kyc-token/route.ts`, was created to manage KYC token interactions on the BSC Testnet.

*   This route handles `POST` requests for two actions:
    *   `checkBalance`: Reads the `balanceOf` function from the specified KYC contract (`0xcc8e8b424464991bbcda036c4781a60334c40628`) using `viem`'s public client.
    *   `mintFree`: Executes the `mintFree` function (selector `0x8ab53447`) on the contract via Privy's `sendTransaction` for authenticated users.
*   Authentication is enforced using `fetchAndVerifyAuthorizationAppRouter`.

The `app/profile/page.tsx` was updated to integrate with this new API, replacing previous mock KYC logic.

*   The component now fetches the user's KYC token balance automatically on load.
*   New `kycStatus` states (`loading`, `no_token`, `has_token`) were introduced to reflect real-time blockchain status.
*   The UI dynamically renders based on `kycStatus`:
    *   A "Mint Free KYC Token" button is displayed when `no_token` is detected, triggering the `mintFree` API call.
    *   When `has_token`, the actual token balance, contract address, and a link to BSC Testnet are shown, along with a "Refresh Balance" button.
*   The `Zap` icon and associated mock benefits section were removed, focusing solely on the blockchain-verified token status.